### PR TITLE
Feature: add spaces transactions

### DIFF
--- a/app/Http/Controllers/RecurringController.php
+++ b/app/Http/Controllers/RecurringController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 
 use App\Recurring;
 use Auth;
+use App\Jobs\ProcessRecurrings;
 
 class RecurringController extends Controller {
     public function index() {
@@ -55,6 +56,7 @@ class RecurringController extends Controller {
         $recurring->amount = (int) ($request->input('amount') * 100);
 
         $recurring->save();
+        ProcessRecurrings::dispatch();
 
         return redirect()->route('recurrings.show', ['id' => $recurring->id]);
     }

--- a/app/Http/Controllers/TransactionController.php
+++ b/app/Http/Controllers/TransactionController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Repositories\TransactionRepository;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 class TransactionController extends Controller {
     public function __construct(TransactionRepository $transactionRepository) {
@@ -25,11 +26,17 @@ class TransactionController extends Controller {
 
     public function create() {
         $tags = [];
+        $spaces = [];
 
         foreach (session('space')->tags as $tag) {
             $tags[] = ['key' => $tag->id, 'label' => '<div class="row"><div class="row__column row__column--compact row__column--middle mr-1"><div style="width: 15px; height: 15px; border-radius: 2px; background: #' . $tag->color . ';"></div></div><div class="row__column row__column--middle">' . $tag->name . '</div></div>'];
         }
 
-        return view('transactions.create', compact('tags'));
+        foreach(Auth::user()->spaces as $space)
+        {
+            $spaces[] = ['key' => $space->id, 'label' => '<div class="row"><div class="row__column row__column--compact row__column--middle mr-1"><div style="width: 15px; height: 15px; border-radius: 2px; background: white;"></div></div><div class="row__column row__column--middle">' . $space->name . '</div></div>'];
+        }
+
+        return view('transactions.create', compact('tags', 'spaces'));
     }
 }

--- a/app/Http/Controllers/TransferController.php
+++ b/app/Http/Controllers/TransferController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+use App\Spending;
+use App\Earning;
+use App\Space;
+
+class TransferController extends Controller
+{
+    public function index() 
+    {
+        //
+    }
+
+    public function store(Request $request)
+    {
+        $validator = Validator::make($request->all(), 
+        [
+            'tag_id' => 'nullable|exists:tags,id', // TODO CHECK IF TAG BELONGS TO USER
+            'space_id' => 'nullable|exists:spaces,id',
+            'date' => 'required|date|date_format:Y-m-d',
+            'description' => 'required|max:255',
+            'amount' => 'required|regex:/^\d*(\.\d{2})?$/'
+        ]);
+
+        if ($validator->fails()) 
+        {
+            // do something!
+        }
+
+        Spending::create([
+            'space_id'      => session('space')->id,
+            'tag_id'        => $request->input('tag_id'),
+            'happened_on'   => $request->input('date'),
+            'description'   => $request->input('description') . ' an ' . Space::where('id', '=', $request->space_id)->first()->name,
+            'amount'        => (int) ($request->input('amount') * 100),
+        ]);
+
+        Earning::create([
+            'space_id'      => $request->space_id,
+            'tag_id'        => $request->input('tag_id'),
+            'happened_on'   => $request->input('date'),
+            'description'   => $request->input('description') . ' von ' . Space::where('id', '=', session('space')->id)->first()->name,
+            'amount'        => (int) ($request->input('amount') * 100),
+        ]);
+
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "type": "project",
     "require": {
         "php": ">=5.6.4",
+        "barryvdh/laravel-debugbar": "^3.2",
         "doctrine/dbal": "^2.8",
         "fideloper/proxy": "^4.0",
         "intervention/image": "^2.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,76 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d6fec4b94dd452da30498b640875bcb7",
+    "content-hash": "763876870560b81e202cd83726fd1754",
     "packages": [
+        {
+            "name": "barryvdh/laravel-debugbar",
+            "version": "v3.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/barryvdh/laravel-debugbar.git",
+                "reference": "5fcba4cc8e92a230b13b99c1083fc22ba8a5c479"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/barryvdh/laravel-debugbar/zipball/5fcba4cc8e92a230b13b99c1083fc22ba8a5c479",
+                "reference": "5fcba4cc8e92a230b13b99c1083fc22ba8a5c479",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/routing": "5.5.x|5.6.x|5.7.x|5.8.x",
+                "illuminate/session": "5.5.x|5.6.x|5.7.x|5.8.x",
+                "illuminate/support": "5.5.x|5.6.x|5.7.x|5.8.x",
+                "maximebf/debugbar": "~1.15.0",
+                "php": ">=7.0",
+                "symfony/debug": "^3|^4",
+                "symfony/finder": "^3|^4"
+            },
+            "require-dev": {
+                "laravel/framework": "5.5.x"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Barryvdh\\Debugbar\\ServiceProvider"
+                    ],
+                    "aliases": {
+                        "Debugbar": "Barryvdh\\Debugbar\\Facade"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Barryvdh\\Debugbar\\": "src/"
+                },
+                "files": [
+                    "src/helpers.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Barry vd. Heuvel",
+                    "email": "barryvdh@gmail.com"
+                }
+            ],
+            "description": "PHP Debugbar integration for Laravel",
+            "keywords": [
+                "debug",
+                "debugbar",
+                "laravel",
+                "profiler",
+                "webprofiler"
+            ],
+            "time": "2019-02-26T18:01:54+00:00"
+        },
         {
             "name": "dnoegel/php-xdg-base-dir",
             "version": "0.1",
@@ -1101,6 +1169,67 @@
                 "storage"
             ],
             "time": "2018-08-22T07:45:22+00:00"
+        },
+        {
+            "name": "maximebf/debugbar",
+            "version": "v1.15.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/maximebf/php-debugbar.git",
+                "reference": "30e7d60937ee5f1320975ca9bc7bcdd44d500f07"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/maximebf/php-debugbar/zipball/30e7d60937ee5f1320975ca9bc7bcdd44d500f07",
+                "reference": "30e7d60937ee5f1320975ca9bc7bcdd44d500f07",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "psr/log": "^1.0",
+                "symfony/var-dumper": "^2.6|^3.0|^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0|^5.0"
+            },
+            "suggest": {
+                "kriswallsmith/assetic": "The best way to manage assets",
+                "monolog/monolog": "Log using Monolog",
+                "predis/predis": "Redis storage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.14-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "DebugBar\\": "src/DebugBar/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Maxime Bouroumeau-Fuseau",
+                    "email": "maxime.bouroumeau@gmail.com",
+                    "homepage": "http://maximebf.com"
+                },
+                {
+                    "name": "Barry vd. Heuvel",
+                    "email": "barryvdh@gmail.com"
+                }
+            ],
+            "description": "Debug bar in the browser for php application",
+            "homepage": "https://github.com/maximebf/php-debugbar",
+            "keywords": [
+                "debug",
+                "debugbar"
+            ],
+            "time": "2017-12-15T11:13:46+00:00"
         },
         {
             "name": "monolog/monolog",

--- a/resources/assets/js/components/TransactionWizard.vue
+++ b/resources/assets/js/components/TransactionWizard.vue
@@ -160,7 +160,32 @@
                 if (!this.loading) {
                     this.loading = true
 
-                    if (this.type == 'spending' && this.isRecurring) { // It's a recurring
+                    if (this.type == 'transfer') 
+                    {
+                        let body = {
+                            _token: document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
+                            date:    this.date,
+                            description: this.description,
+                            amount: this.amount
+                        }
+
+                        if (this.tag)
+                        {
+                            body.tag_id = this.tag
+                        }
+
+                        if (this.space)
+                        {
+                            body.space_id = this.space
+                        }
+
+                        axios.post('/transfers', body).then(response => {
+                            this.handleSuccess()
+                        }).catch(error => {
+                            this.handleErrors(error.response)
+                        })
+                    }
+                    else if (this.type == 'spending' && this.isRecurring) { // It's a recurring
                         let body = {
                             _token: document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
                             day: this.date.slice(-2),

--- a/resources/assets/js/components/TransactionWizard.vue
+++ b/resources/assets/js/components/TransactionWizard.vue
@@ -9,8 +9,12 @@
                 class="bg__button"
                 :class="{ 'bg__button--active': type == 'spending' }"
                 @click="switchType('spending')">Spending</button>
+            <button
+                class="bg__button"
+                :class="{ 'bg__button--active': type == 'transfer' }"
+                @click="switchType('transfer')">Transfer</button>
         </div>
-        <div class="input" v-if="type == 'spending'">
+        <div class="input" v-if="type != 'earning'">
             <label>Tag</label>
             <searchable
                 name="tag"
@@ -35,24 +39,32 @@
             <input type="text" v-model="amount" />
             <validation-error v-if="errors.amount" :message="errors.amount"></validation-error>
         </div>
-        <div v-if="type == 'spending'">
+        <div class="input" v-if="type == 'transfer'">
+            <label>Space</label>
+            <searchable
+                name="space"
+                :items="spaces"
+                @SelectUpdated="spaceUpdated"></searchable>
+            <validation-error v-if="errors.space_id" :message="errors.space_id"></validation-error>
+        </div>
+        <div v-if="type != 'earning'">
             <div class="input row">
                 <div class="row__column row__column--compact mr-1">
                     <input type="checkbox" id="test" v-model="isRecurring" />
                 </div>
                 <div class="row__column">
-                    <label for="test">This is a recurring spending&mdash;create it for me in the future</label>
+                    <label for="test">This is a recurring transaction, create it for me in the future</label>
                 </div>
             </div>
             <div v-if="isRecurring">
                 <div class="input">
-                    <label>How long will this spending go on for?</label>
+                    <label>How long will this transfer occur?</label>
                     <div class="row">
                         <div class="row__column row__column--compact mr-1">
                             <input id="noEnd" type="radio" v-model="recurringEnd" value="forever" />
                         </div>
                         <div class="row__column">
-                            <label for="noEnd">Forever :(</label>
+                            <label for="noEnd">Forever!</label>
                         </div>
                     </div>
                     <div class="row">
@@ -85,7 +97,10 @@
 
 <script>
     export default {
-        props: ['tags'],
+        props: [
+            'tags', 
+            'spaces'
+        ],
 
         data() {
             return {
@@ -93,6 +108,7 @@
                 errors: [],
 
                 tag: null,
+                space: null,
                 date: this.getTodaysDate(),
                 description: '',
                 amount: '10.00',
@@ -124,6 +140,10 @@
 
             tagUpdated(payload) {
                 this.tag = payload.key
+            },
+
+            spaceUpdated(payload) {
+                this.space = payload.key
             },
 
             getTodaysDate() {

--- a/resources/views/transactions/create.blade.php
+++ b/resources/views/transactions/create.blade.php
@@ -4,7 +4,7 @@
 
 @section('body')
     <div class="wrapper mw-400 my-3">
-        <h2 class="mb-3">{{ __('actions.create') }} Transaction</h2>
-        <transaction-wizard :tags='@json($tags)'></transaction-wizard>
+        <h2 class="mb-3">{{ __('actions.create') }} Transaction for {{ session('space')->name }}</h2>
+        <transaction-wizard :tags='@json($tags)' :spaces='@json($spaces)'></transaction-wizard>
     </div>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -41,6 +41,10 @@ Route::group(['middleware' => ['auth']], function () {
         Route::post('/spendings/{id}/restore', 'SpendingController@restore');
     });
 
+    Route::name('transfers')->group(function () {
+        Route::post('/transfers', 'TransferController@store');
+    });
+
     Route::resource('/recurrings', 'RecurringController')->only([
         'index',
         'create',

--- a/storage/debugbar/.gitignore
+++ b/storage/debugbar/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
With this pull request a new option "Transfers" is added to the transaction wizard. 
This enables the user to make transfers from one space to another with just one transaction, instead of having to add a spending on one space and an earning on another. 

Transfers will add the description appended by the associated space, so that it's clear where that transaction came from.
This closes #5 .